### PR TITLE
prevent stop tapping from hiding the button

### DIFF
--- a/lib/src/scroll_wrapper.dart
+++ b/lib/src/scroll_wrapper.dart
@@ -212,17 +212,18 @@ class _ScrollWrapperState extends State<ScrollWrapper> {
       if (widget.alwaysVisibleAtOffset) {
         _checkState();
       } else if (direction == ScrollDirection.forward) {
-        _currentScrollStartOffset =
-            _currentScrollStartOffset ?? _scrollController.offset;
+        _currentScrollStartOffset ??= _scrollController.offset;
         if (_currentScrollStartOffset! - _scrollController.offset >
             widget.scrollOffsetUntilVisible) {
           _checkState();
         }
       } else {
-        setState(() {
-          _scrollTopAtOffset = false;
-        });
-        _currentScrollStartOffset = null;
+        if (_scrollController.offset - _currentScrollStartOffset! > 10) {
+          setState(() {
+            _scrollTopAtOffset = false;
+          });
+          _currentScrollStartOffset = null;
+        }
       }
     });
   }


### PR DESCRIPTION
This PR aims to prevent the button from hiding if the user taps the screen to stop a ballistic scroll upwards.

The small offset of `10` will prevent the button from hiding immediately,
in cases where the scroll downwards is minimal.

I did not test how well the value `10` works, and I did not include it in a parameter or a constant.
Those things might need to be considered.